### PR TITLE
Fix intent action typo in manifest

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -14,7 +14,7 @@
         </activity>
         <activity android:name=".MyVirusActivity">
             <intent-filter>
-                <action android:name="android.inte.action.MAIN"/>
+                <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>


### PR DESCRIPTION
## Summary
- fix typo in `AndroidManifest.xml` that referenced an invalid intent action

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68410dbdf48c8333a22e01a83f3b9a30